### PR TITLE
Expose NEXUS_HOST as option in the constructor

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,7 @@ class Nest extends Auth {
     refreshToken: null,
     apiKey: null,
     clientId: null,
+    nexusHost: "https://nexusapi-us1.dropcam.com", // Default value
     snapshotInterval: 5000,
     eventInterval: 3000,
   }) {
@@ -153,8 +154,10 @@ class Nest extends Auth {
     if (end) query += `&end_time=${end}`;
 
     const options = {
-      method: 'GET',
-      url: `${this.config.urls.NEXUS_HOST}${this.config.endpoints.getEventsEndpoint(this._id)}${query}`,
+      method: "GET",
+      url: `${this._options.nexusHost}${this.config.endpoints.getEventsEndpoint(
+        this._id
+      )}${query}`,
       headers: {
         Authorization: `Basic ${this.jwtToken}`,
       },
@@ -182,7 +185,7 @@ class Nest extends Auth {
   async getLatestSnapshot() {
     const options = {
       method: 'GET',
-      url: `${this.config.urls.NEXUS_HOST}${this.config.endpoints.getLatestImageEndpoint(this._id)}`,
+      url: `${this._options.nexusHost}${this.config.endpoints.getLatestImageEndpoint(this._id)}`,
       headers: {
         Authorization: `Basic ${this.jwtToken}`,
       },
@@ -218,12 +221,16 @@ class Nest extends Auth {
       throw new Error('JWT token is null or undefined. Call #fetchJwtToken() to retrieve new json web token.');
     }
     const options = {
-      method: 'GET',
-      url: `${this.config.urls.NEXUS_HOST}${this.config.endpoints.getSnapshotEndpoint(this._id)}${id}?crop_type=timeline&width=300`,
+      method: "GET",
+      url: `${
+        this._options.nexusHost
+      }${this.config.endpoints.getSnapshotEndpoint(
+        this._id
+      )}${id}?crop_type=timeline&width=300`,
       headers: {
         Authorization: `Basic ${this.jwtToken}`,
       },
-      responseType: 'stream',
+      responseType: "stream",
     };
     DEBUG && console.log(chalk.green('[DEBUG] Making Http Request to retrieve snapshot with the id: '), chalk.blue(id));
     return new Promise((res, rej) => {


### PR DESCRIPTION
This PR introduces a modification to the NEXUS_HOST configuration to account for regional differences between Europe and the USA.

Changes Made
	•	Updated the NEXUS_HOST configuration to support different endpoints for Europe (https://nexusapi-eu1.dropcam.com) and the USA (https://nexusapi-us1.dropcam.com).
	•	Removed hardcoded NEXUS_HOST values and introduced a more flexible approach to setting the correct endpoint based on region.

Why this Change?

Currently, the system is defaulting to a single NEXUS_HOST (https://nexusapi-us1.dropcam.com), which does not work correctly for users in Europe. Dropcam provides two different API hosts:
	•	USA: https://nexusapi-us1.dropcam.com
	•	Europe: https://nexusapi-eu1.dropcam.com

To ensure proper functionality across different regions, we need to dynamically set the appropriate URL.

Next Steps
	•	Verify that the correct endpoint is used based on the user’s region.
	•	If needed, introduce a configuration setting or automatic detection to determine whether to use the EU or US URL.

Let me know if you have any questions! 🚀